### PR TITLE
Fix session names falling back to UUIDs on large transcripts

### DIFF
--- a/server.js
+++ b/server.js
@@ -58,10 +58,12 @@ function readSessionInfoFromJsonl(jsonlPath) {
   try {
     if (!existsSync(jsonlPath)) return result;
 
-    // Read first 64KB - should contain custom-title and at least one message with slug/cwd
+    // Read first 1MB - the first user message can be huge (large CLAUDE.md /
+    // rule imports get embedded in it), pushing slug/cwd past a small window
+    const READ_WINDOW = 1048576;
     const fd = require('fs').openSync(jsonlPath, 'r');
-    const buffer = Buffer.alloc(65536);
-    const bytesRead = require('fs').readSync(fd, buffer, 0, 65536, 0);
+    const buffer = Buffer.alloc(READ_WINDOW);
+    const bytesRead = require('fs').readSync(fd, buffer, 0, READ_WINDOW, 0);
     require('fs').closeSync(fd);
 
     const content = buffer.toString('utf8', 0, bytesRead);
@@ -92,6 +94,17 @@ function readSessionInfoFromJsonl(jsonlPath) {
       } catch (e) {
         // Skip malformed lines
       }
+    }
+
+    // Fallback: a single giant line (or one truncated at the window edge)
+    // fails JSON.parse above, so regex-scan the raw content for the fields
+    if (!result.slug) {
+      const m = content.match(/"slug":"([^"]+)"/);
+      if (m) result.slug = m[1];
+    }
+    if (!result.projectPath) {
+      const m = content.match(/"cwd":"([^"]+)"/);
+      if (m) result.projectPath = m[1];
     }
   } catch (e) {
     // Return partial results


### PR DESCRIPTION
## Problem

`readSessionInfoFromJsonl` reads only the first 64KB of a session's JSONL to find the `slug` / `cwd` / `customTitle`. In projects with a large `CLAUDE.md` (or many `@`-imported rule files), that content is embedded in the first user message, pushing the `slug` field past the 64KB window — observed at byte ~138K in a real project. The lookup silently fails and every session board in that project is labeled with the raw UUID instead of a readable name.

## Fix

- Read a 1MB window instead of 64KB.
- Add a regex fallback for `slug` and `cwd` on the raw content: a single giant line (or one truncated at the window edge) fails the line-by-line `JSON.parse`, so the parse loop alone can still miss fields that are present in the window. `customTitle` keeps the parse-only path since `/rename` writes it as a small standalone line.

## Result

In the affected project, 5 of 7 session boards went from raw UUIDs to their slugs/custom titles; resolving the slug also unlocked the `sessions-index.json` title merge. The remaining two genuinely have no slug in their transcripts.