### PR TITLE
Escape quotes in escapeHtml

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2152,7 +2152,7 @@
       const tooltip = [timeDisplay, gitBranch ? `Branch: ${gitBranch}` : ''].filter(Boolean).join(' | ');
 
       return `
-        <button onclick="fetchTasks('${session.id}')" class="session-item ${isActive ? 'active' : ''} ${isArchived ? 'archived' : ''}" title="${tooltip}">
+        <button onclick="fetchTasks('${session.id}')" class="session-item ${isActive ? 'active' : ''} ${isArchived ? 'archived' : ''}" title="${escapeHtml(tooltip)}">
           <div class="session-name">
             <span>${escapeHtml(primaryName)}</span>
             ${hasInProgress ? '<span class="pulse"></span>' : ''}
@@ -2664,9 +2664,9 @@
     }
 
     function escapeHtml(text) {
-      const div = document.createElement('div');
-      div.textContent = text;
-      return div.innerHTML;
+      return String(text ?? '').replace(/[&<>"']/g, c => ({
+        '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+      })[c]);
     }
 
     function filterBySessions(value) {
@@ -2787,7 +2787,7 @@
         const widthPct = Math.max(((end - start) / span) * 100, 0.5);
         const statusClass = task.status === 'in_progress' ? 'in_progress' : task.status;
         const actualSessionId = task.sessionId || currentSessionId;
-        const safeSubject = escapeHtml(task.subject).replace(/'/g, '&#39;');
+        const safeSubject = escapeHtml(task.subject);
 
         return `
           <div class="timeline-row"


### PR DESCRIPTION
## Security: `escapeHtml` doesn't escape quotes

`escapeHtml()` round-trips through `textContent` → `innerHTML`, which escapes `&`, `<` and `>` but leaves `"` and `'` untouched. Every call inside a quoted HTML attribute was therefore unsafe while *looking* defended.

Confirmed in a browser against a task whose subject is:

```
Break" onmouseover="window.__XSS_FIRED=1" x="
```

**Before** — the rendered timeline row carries real injected attributes and the handler executes on hover:

```js
[...row.attributes].map(a => a.name)
// ["class", "onclick", "data-subject", "onmouseover", "x", "data-created", ...]
window.__XSS_FIRED // 1
```

**After** — the subject stays inert text inside `data-subject`/`title`, and no attribute is created:

```js
// ["class", "onclick", "data-subject", "data-created", "data-updated", ...]
window.__XSS_FIRED // undefined
```

Task JSON is written from agent and tool output, so this is reachable from ordinary untrusted content rather than only a hand-edited file.

## Also in this PR

- **Drops the ad-hoc `escapeHtml(subject).replace(/'/g, '&#39;')`** in `renderTimeline`. It covered only the single quote, so the double quote in the payload above sailed straight through into `title="…"` and `data-subject="…"`. With `escapeHtml` handling both, the hand-rolled pass is redundant.
- **Wraps the session-item `title` attribute**, which concatenates the git branch name onto an element that already carries an `onclick`.

## Scope — what this deliberately does *not* fix

This does **not** fix the inline `onclick` handlers. Entity-escaping cannot defend a JS context nested inside an HTML attribute: the parser decodes `&#39;` back to `'` before the JS compiler ever sees it, so the string literal still closes. `onclick="showTaskDetail('${task.id}', …)"` needs the handler *gone*, not escaped — that's a separate, larger change (event delegation + `data-` attributes) which I'd rather not bundle into a 5-line fix.

Worth knowing: of the 40 `onclick`/`onsubmit` attributes in the file, only 9 interpolate data at all. The other 31 are static literals with no injection surface.

## Behaviour note

`escapeHtml(undefined)` now returns `""` where it previously returned the literal string `"undefined"`. Strictly an improvement, but it is a change.
