### PR TITLE
Resolve session-XXXXXXXX task dirs to their full-UUID metadata

### DIFF
--- a/server.js
+++ b/server.js
@@ -39,6 +39,7 @@ const clients = new Set();
 
 // Cache for session metadata (refreshed periodically)
 let sessionMetadataCache = {};
+let sessionAliasCache = {};
 let lastMetadataRefresh = 0;
 const METADATA_CACHE_TTL = 10000; // 10 seconds
 
@@ -110,6 +111,9 @@ function loadSessionMetadata() {
   }
 
   const metadata = {};
+  // 8-hex-prefix -> [full session ids]. Used to build aliases below; a prefix
+  // claimed by more than one session is dropped rather than guessed at.
+  const prefixOwners = {};
 
   try {
     if (!existsSync(PROJECTS_DIR)) {
@@ -138,6 +142,11 @@ function loadSessionMetadata() {
           project: sessionInfo.projectPath || null,
           jsonlPath: jsonlPath
         };
+
+        const prefix = sessionId.slice(0, 8);
+        if (/^[0-9a-f]{8}$/i.test(prefix)) {
+          (prefixOwners[prefix] = prefixOwners[prefix] || []).push(sessionId);
+        }
       }
 
       // Also check sessions-index.json for custom names (if /rename was used)
@@ -164,9 +173,34 @@ function loadSessionMetadata() {
     console.error('Error loading session metadata:', e);
   }
 
+  // Newer Claude Code names task dirs session-XXXXXXXX (first 8 chars of the
+  // session UUID) while the transcript is still <full-uuid>.jsonl, so the
+  // metadata lookup misses and every such session loses its name and project.
+  //
+  // 8 hex chars is only 32 bits, so prefixes do collide -- roughly 1% odds by
+  // ~9,300 sessions. Rather than guess, only alias a prefix owned by exactly
+  // one session; on a collision we emit nothing and behaviour is unchanged.
+  const aliases = {};
+  for (const [prefix, owners] of Object.entries(prefixOwners)) {
+    if (owners.length !== 1) continue;
+    aliases[prefix] = owners[0];
+    aliases[`session-${prefix}`] = owners[0];
+  }
+
   sessionMetadataCache = metadata;
+  sessionAliasCache = aliases;
   lastMetadataRefresh = now;
   return metadata;
+}
+
+/**
+ * Look up session metadata by task-directory name, falling back to an
+ * unambiguous short-id alias. Exact matches always win.
+ */
+function getSessionMeta(metadata, dirName) {
+  if (metadata[dirName]) return metadata[dirName];
+  const aliased = sessionAliasCache[dirName];
+  return (aliased && metadata[aliased]) || {};
 }
 
 /**
@@ -228,7 +262,7 @@ app.get('/api/sessions', async (req, res) => {
           }
 
           // Get metadata for this session
-          const meta = metadata[entry.name] || {};
+          const meta = getSessionMeta(metadata, entry.name);
 
           // Use newest task file mtime, or fall back to directory mtime if no tasks
           const modifiedAt = newestTaskMtime ? newestTaskMtime.toISOString() : stat.mtime.toISOString();
@@ -318,7 +352,7 @@ app.get('/api/tasks/all', async (req, res) => {
     for (const sessionDir of sessionDirs) {
       const sessionPath = path.join(TASKS_DIR, sessionDir.name);
       const taskFiles = readdirSync(sessionPath).filter(f => f.endsWith('.json'));
-      const meta = metadata[sessionDir.name] || {};
+      const meta = getSessionMeta(metadata, sessionDir.name);
 
       for (const file of taskFiles) {
         try {


### PR DESCRIPTION
Fixes #19.

## The bug

Newer Claude Code names task directories `session-XXXXXXXX` using the first 8 chars of the session UUID, while the transcript is still written as `<full-uuid>.jsonl`. `loadSessionMetadata` keys off the JSONL filename and `/api/sessions` looks up by task-directory name, so the keys never match — `name` and `project` come back `null` for every such session, and the "All Projects" dropdown ends up empty because it's built from exactly those values.

## Reproduction caveat, stated up front

**I could not reproduce this locally.** Claude Code 2.1.227 writes 7/7 full-UUID task dirs on this machine and zero `session-` ones, so the reporter is presumably on a different build. This patch is therefore written to be a **no-op when the triggering layout is absent**, and was verified against a synthetic directory that reproduces it.

## Two deliberate differences from the fix suggested in the issue

**1. Aliases live in their own cache**, not written into the metadata map. An alias then cannot shadow a real entry, exact matches win structurally rather than by insertion order, and anything that iterates the metadata map doesn't see phantom duplicate sessions. (That last one matters if a second pass over `metadata` is ever added — as in #29.)

**2. Aliases are only emitted for a prefix owned by exactly one session.** 8 hex chars is 32 bits, so collisions aren't hypothetical — roughly 1% odds by ~9,300 sessions and ~50% by ~77,000, and heavy users do accumulate thousands of transcripts. An unconditional alias would confidently attribute a session to the **wrong** project, which is worse than showing a UUID. On a collision this emits nothing and behaviour is exactly as today.

## Verification

| scenario | result |
|---|---|
| `tasks/session-054ba1af` + one `054ba1af-….jsonl` | resolves to that transcript's slug and cwd |
| after adding a second JSONL sharing the `054ba1af` prefix | back to `null` — refuses to guess |
| full-UUID task dirs (synthetic + real) | unaffected |
