### PR TITLE
Surface sessions that have no tasks directory

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1664,7 +1664,7 @@
     let currentSessionId = null;
     let currentTasks = [];
     let viewMode = 'session';
-    let sessionFilter = localStorage.getItem('sessionFilter') || 'all'; // 'all' or 'active'
+    let sessionFilter = localStorage.getItem('sessionFilter') || 'with-tasks'; // 'with-tasks' | 'all' | 'active'
     let sessionLimit = localStorage.getItem('sessionLimit') || '20'; // '10', '20', '50', 'all'
     let filterProject = null; // null = all projects, or project path to filter
     let searchQuery = ''; // Search query for fuzzy search
@@ -2101,6 +2101,9 @@
         } else if (sessionFilter === 'active') {
           emptyMsg = 'No active sessions';
           emptyHint = 'Select "All Sessions" to see all';
+        } else if (sessionFilter === 'with-tasks') {
+          emptyMsg = 'No sessions with tasks';
+          emptyHint = 'Select "All Sessions" to include sessions that have none';
         }
         sessionsList.innerHTML = `
           <div style="padding: 24px 12px; text-align: center; color: var(--text-muted); font-size: 12px;">

--- a/public/index.html
+++ b/public/index.html
@@ -2974,14 +2974,18 @@
     }
     setupEventSource();
 
-    // Fetch sessions and show newest one by default
+    // Fetch sessions and show the newest one that actually has tasks. Sessions
+    // without a tasks directory are legitimate and listed, but opening one on
+    // boot shows an empty board and 404s /api/sessions/:id on every refresh,
+    // so they are a poor default landing view.
     fetchSessions().then(() => {
-      if (sessions.length > 0) {
-        // Sessions are already sorted by newest first from API
-        fetchTasks(sessions[0].id);
-      } else {
+      if (sessions.length === 0) {
         showAllTasks();
+        return;
       }
+      // already sorted newest-first by the API
+      const landing = sessions.find(s => s.hasTasks !== false) || sessions[0];
+      fetchTasks(landing.id);
     });
   </script>
 

--- a/public/index.html
+++ b/public/index.html
@@ -385,6 +385,12 @@
       font-variant-numeric: tabular-nums;
     }
 
+    .session-no-tasks {
+      font-size: 10px;
+      color: var(--text-muted);
+      font-style: italic;
+    }
+
     .session-time {
       font-size: 10px;
       color: var(--text-muted);
@@ -1515,6 +1521,7 @@
           </select>
           <select id="session-filter" class="filter-dropdown" onchange="filterBySessions(this.value)">
             <option value="all">All Sessions</option>
+            <option value="with-tasks">With Tasks</option>
             <option value="active">Active Only</option>
           </select>
         </div>
@@ -1697,7 +1704,8 @@
           oldStatuses.set(key, task.status);
         }
 
-        const res = await fetch(`/api/sessions?limit=${sessionLimit}`);
+        const withTasks = sessionFilter === 'with-tasks' ? '&withTasks=1' : '';
+        const res = await fetch(`/api/sessions?limit=${sessionLimit}${withTasks}`);
         sessions = await res.json();
         console.log('[fetchSessions] Sessions loaded:', sessions.length);
 
@@ -2045,6 +2053,10 @@
       let filteredSessions = sessions;
       if (sessionFilter === 'active') {
         filteredSessions = filteredSessions.filter(s => s.pending > 0 || s.inProgress > 0);
+      } else if (sessionFilter === 'with-tasks') {
+        // the server already applied this before limiting; kept as a no-op
+        // safety net so the option still works against an older server
+        filteredSessions = filteredSessions.filter(s => s.hasTasks !== false);
       }
       if (filterProject) {
         filteredSessions = filteredSessions.filter(s => s.project === filterProject);
@@ -2159,10 +2171,12 @@
           </div>
           ${secondaryName ? `<div class="session-secondary">${escapeHtml(secondaryName)}</div>` : ''}
           ${gitBranch ? `<div class="session-branch">${gitBranch}</div>` : ''}
-          <div class="session-progress">
+          ${session.hasTasks === false
+            ? '<div class="session-progress"><span class="session-no-tasks">No tasks</span></div>'
+            : `<div class="session-progress">
             <div class="progress-bar"><div class="progress-fill" style="width: ${percent}%"></div></div>
             <span class="progress-text">${session.completed}/${total}</span>
-          </div>
+          </div>`}
           <div class="session-time">${formatDate(session.modifiedAt)}</div>
         </button>
       `;
@@ -2672,7 +2686,9 @@
     function filterBySessions(value) {
       sessionFilter = value;
       localStorage.setItem('sessionFilter', sessionFilter);
-      renderSessions();
+      // 'with-tasks' is applied server-side (before the limit), so the session
+      // list has to be refetched rather than just re-rendered
+      fetchSessions();
     }
 
     function changeSessionLimit(value) {

--- a/server.js
+++ b/server.js
@@ -189,6 +189,9 @@ app.get('/api/sessions', async (req, res) => {
     // Parse limit parameter (default: 20, "all" for unlimited)
     const limitParam = req.query.limit || '20';
     const limit = limitParam === 'all' ? null : parseInt(limitParam, 10);
+    // Filtering has to happen before the limit, or "N most recent" silently
+    // becomes "however many of the N most recent happen to match".
+    const withTasksOnly = req.query.withTasks === '1';
 
     const metadata = loadSessionMetadata();
     const sessionsMap = new Map();
@@ -244,6 +247,7 @@ app.get('/api/sessions', async (req, res) => {
             completed,
             inProgress,
             pending,
+            hasTasks: true,
             createdAt: meta.created || null,
             modifiedAt: modifiedAt
           });
@@ -251,8 +255,48 @@ app.get('/api/sessions', async (req, res) => {
       }
     }
 
+    // Then add sessions known only from the transcripts in PROJECTS_DIR.
+    // Claude Code only creates a tasks directory once a session actually
+    // writes a todo, so a session that never used one was previously
+    // unreachable through any endpoint.
+    for (const [sessionId, meta] of Object.entries(metadata)) {
+      if (sessionsMap.has(sessionId)) continue;
+
+      // mtime of the transcript, not of a directory. The task-dir fallback
+      // above uses directory mtime, which Claude Code bumps when it removes
+      // its .lock at session end -- that timestamp reflects teardown rather
+      // than activity, so it is not repeated here.
+      let modifiedAt = null;
+      try {
+        modifiedAt = statSync(meta.jsonlPath).mtime.toISOString();
+      } catch (e) {
+        continue; // transcript vanished between the scan and now
+      }
+
+      sessionsMap.set(sessionId, {
+        id: sessionId,
+        name: getSessionDisplayName(sessionId, meta),
+        slug: meta.slug || null,
+        project: meta.project || null,
+        description: meta.description || null,
+        gitBranch: meta.gitBranch || null,
+        taskCount: 0,
+        completed: 0,
+        inProgress: 0,
+        pending: 0,
+        hasTasks: false,
+        createdAt: meta.created || null,
+        modifiedAt
+      });
+    }
+
     // Convert map to array and sort by most recently modified
     let sessions = Array.from(sessionsMap.values());
+
+    if (withTasksOnly) {
+      sessions = sessions.filter(s => s.hasTasks);
+    }
+
     sessions.sort((a, b) => new Date(b.modifiedAt) - new Date(a.modifiedAt));
 
     // Apply limit if specified


### PR DESCRIPTION
Fixes #18.

## The bug

`/api/sessions` enumerates only `TASKS_DIR`. The comment above that loop reads:

```js
// First, add sessions that have tasks directories
```

…but the second pass it implies was never written. Claude Code only creates a tasks directory once a session actually writes a todo, so **any ordinary conversation that never used one is unreachable through any endpoint** — no limit, filter, or sort will surface it.

On my machine that's **30 of 37 sessions invisible**.

A strong hint this was always intended: `fetchTasks` already handles the 404 for a missing tasks directory, with a comment reading *"Session has no tasks directory yet."* Clicking one of these sessions already worked — there was simply no way to reach it.

## The fix

**Server** — after the existing loop, add sessions known only from the transcripts in `PROJECTS_DIR`, with `taskCount: 0` and `hasTasks: false`.

`modifiedAt` comes from the transcript's mtime rather than a directory's. Note the existing task-less fallback uses *directory* mtime, which Claude Code bumps when it removes its `.lock` at session end — so that timestamp reflects teardown rather than activity. I didn't repeat that here, and haven't changed the existing fallback in this PR.

**Client** — these render `No tasks` instead of a `0/0` progress bar, which otherwise reads as "nothing done yet" rather than "never had any".

## Interactions, all checked

- **"Active Only" is unchanged.** It requires `pending > 0 || inProgress > 0`, and these sessions are all zero, so they were already excluded.
- **Auto-archive absorbs most of them.** Most are older than the 7-day threshold, so they land in the collapsed *Archived* disclosure rather than the main list.
- **The default limit of 20 was the real risk**, and it needed more than the obvious fix. Applied naively, 30 new sessions compete for those slots and the default view drops from **7** task-bearing sessions to **6** — a regression for anyone who only cares about sessions with tasks.

So the new **"With Tasks"** filter is applied **server-side, before the limit**, rather than client-side after it:

```
?limit=20              → 20 shown, 6 with tasks
?limit=20&withTasks=1  →  7 shown, 7 with tasks   ← exactly the old view
```

Filtering after limiting would quietly turn "20 most recent" into "however many of the 20 most recent happen to match". `filterBySessions` now refetches rather than only re-rendering, since that filter is no longer purely client-side; the client-side filter is kept as a no-op safety net so the option still behaves against an older server.

## This is non-breaking by default

**"With Tasks" is the default**, so the out-of-the-box sidebar is byte-for-byte the view you have today — the 30 newly-reachable sessions are one click away rather than in your face. On my machine they outnumber the rest 30:7, and as a default they bury the thing you opened the app to look at.

Only the default changes. `sessionFilter` is written to localStorage solely by `filterBySessions` — i.e. only when a user picks something — so anyone who has explicitly chosen "All Sessions" keeps it. Verified both: a first run with no stored value lands on `with-tasks` with no implicit write, and a stored `'all'` still loads as `'all'`.

If you'd rather ship it the other way round, flipping the default is a one-line change.

## Note on ordering

If you take #28 as well, that one keeps its short-id aliases in a separate cache specifically so this second pass — which iterates `Object.entries(metadata)` — doesn't manufacture phantom duplicate sessions from alias keys. They're order-independent either way.
