### PR TITLE
Pin CDN scripts with SRI and degrade gracefully without them

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,8 +7,12 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=Playfair+Display:wght@400;500;600&display=swap" rel="stylesheet">
-  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/dompurify@3/dist/purify.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/marked@15.0.12/marked.min.js"
+          integrity="sha384-948ahk4ZmxYVYOc+rxN1H2gM1EJ2Duhp7uHtZ4WSLkV4Vtx5MUqnV+l7u9B+jFv+"
+          crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/dompurify@3.4.14/dist/purify.min.js"
+          integrity="sha384-46dPGH1XlTmj7bc50bqLjTdORXs/3EP2QpA/6EWbelYWOY9VGp+87RT61S3Mcslb"
+          crossorigin="anonymous"></script>
   <style>
     :root {
       --bg-deep: #08090a;
@@ -867,6 +871,15 @@
     .detail-desc {
       font-size: 13px;
       line-height: 1.7;
+      color: var(--text-secondary);
+    }
+
+    .detail-desc-plain {
+      white-space: pre-wrap;
+      word-break: break-word;
+      font-family: var(--mono);
+      font-size: 12px;
+      margin: 0;
       color: var(--text-secondary);
     }
 
@@ -2391,7 +2404,7 @@
 
         <div class="detail-section">
           <div class="detail-label">Description</div>
-          <div class="detail-desc">${task.description ? DOMPurify.sanitize(marked.parse(task.description)) : '<em style="color: var(--text-muted);">No description</em>'}</div>
+          <div class="detail-desc">${task.description ? renderMarkdown(task.description) : '<em style="color: var(--text-muted);">No description</em>'}</div>
         </div>
 
         <div class="detail-section note-section">
@@ -2661,6 +2674,18 @@
       if (diff < 3600000) return `${Math.floor(diff / 60000)}m ago`;
       if (diff < 86400000) return `${Math.floor(diff / 3600000)}h ago`;
       return date.toLocaleDateString();
+    }
+
+    // marked and DOMPurify come from a CDN. If either is missing (offline, CDN
+    // blocked, SRI mismatch) the old code threw while building the detail
+    // panel's template literal -- so innerHTML was never assigned, the panel
+    // kept showing the previously opened task, and the line that wires up the
+    // delete button never ran. Degrade to escaped plain text instead.
+    function renderMarkdown(md) {
+      if (typeof marked === 'undefined' || typeof DOMPurify === 'undefined') {
+        return `<pre class="detail-desc-plain">${escapeHtml(md)}</pre>`;
+      }
+      return DOMPurify.sanitize(marked.parse(md));
     }
 
     function escapeHtml(text) {


### PR DESCRIPTION
Two related problems. The guard is what makes the pin safe to add, so they're one PR.

## 1. `marked` is unpinned — and worse than it looks

```html
<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
```

No version. But marked **removed `marked.min.js` from its dist in v16**, so jsDelivr currently falls back to serving **v15.0.12** from that path:

```
$ curl -sI https://cdn.jsdelivr.net/npm/marked/marked.min.js   → 200, 39903 bytes
$ curl -s  https://cdn.jsdelivr.net/npm/marked/marked.min.js | head -1
  /** marked v15.0.12 ... */
$ curl -s  https://cdn.jsdelivr.net/npm/marked@18.0.10/marked.min.js | wc -c
  0
```

So the app isn't unpinned in the "next major breaks you" sense — it's pinned to a **CDN fallback behaviour**. If jsDelivr ever changes how it resolves a missing file, markdown rendering breaks for every user simultaneously.

Pinned explicitly to `marked@15.0.12`, which is **byte-identical** to what the unpinned URL serves today (verified by sha256), so this is a zero-behaviour-change edit. `dompurify@3` → `3.4.14`. Both now carry `integrity` + `crossorigin`.

## 2. Missing globals silently corrupt the detail panel

`DOMPurify.sanitize(marked.parse(...))` is called inline inside the detail panel's template literal. If either global is absent — offline, CDN blocked, or now an SRI mismatch — it throws *while the string is being built*, so `detailContent.innerHTML` is never assigned and the line after it never runs.

The visible result isn't an error. Confirmed against the unpatched build:

1. Open task #3 (CDN available)
2. Drop the globals
3. Click task #6

→ the panel still reads **"Task #3"**, and `delete-task-btn.onclick` is **still bound to task #3**.

So a user in that state who presses delete removes a task they aren't looking at. That's the part that pushed this above "cosmetic" for me.

## The fix

`renderMarkdown()` checks for both globals and falls back to escaped plain text in a `<pre>`. Verified with the globals deleted at runtime: no throw, the panel shows the task actually clicked, the fallback renders, and the delete button is rebound correctly.

| | unpatched | patched |
|---|---|---|
| throws | swallowed | none |
| panel content | **previous task** | correct task |
| delete button | **bound to previous task** | rebound correctly |
| description | stale HTML | plain text |

## Deliberately not vendoring

~120 KB of third-party minified JS into a repo with no build step and no update story. Pin + SRI + guard gets offline *degradation* without that cost. Google Fonts is left alone — the CSS already declares `monospace`/`serif` fallbacks, so offline is cosmetic there.
